### PR TITLE
Replace PNG icons with SVG and improve color accessibility

### DIFF
--- a/Vestib_CI/asterisk.svg
+++ b/Vestib_CI/asterisk.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="2.5" stroke-linecap="round">
+  <line x1="12" y1="3" x2="12" y2="21"/>
+  <line x1="3.22" y1="7.5" x2="20.78" y2="16.5"/>
+  <line x1="20.78" y1="7.5" x2="3.22" y2="16.5"/>
+</svg>

--- a/Vestib_CI/check.svg
+++ b/Vestib_CI/check.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="4 12 9.5 18 20 6"/>
+</svg>

--- a/Vestib_CI/index.js
+++ b/Vestib_CI/index.js
@@ -1,15 +1,15 @@
 const emptyBoxes = document.querySelectorAll(".result");
 const checkedImage = new Image();
-checkedImage.src = "Checked1.png";
+checkedImage.src = "check.svg";
 checkedImage.classList.add("img-sizer");
 const tildeImage = new Image();
-tildeImage.src = "Tilde1.png";
+tildeImage.src = "tilde.svg";
 tildeImage.classList.add("img-sizer");
 const xImage = new Image();
-xImage.src = "Xmark1.png";
+xImage.src = "xmark.svg";
 xImage.classList.add("img-sizer");
 const asterisk = new Image();
-asterisk.src = "Asterisk.png";
+asterisk.src = "asterisk.svg";
 
 emptyBoxes.forEach((div) => {
   div.setAttribute("data-state", "emptyBox");

--- a/Vestib_CI/styles.css
+++ b/Vestib_CI/styles.css
@@ -135,13 +135,23 @@ body {
 
 /* State color classes */
 .good {
-  background-color: green;
+  background-color: #2a8c2a;
 }
 
 .mild {
-  background-color: yellow;
+  background-color: #d4a800;
 }
 
 .severe {
-  background-color: red;
+  background-color: #c02020;
+}
+
+/* White marks on dark backgrounds; black marks on amber */
+.good img,
+.severe img {
+  filter: brightness(0) invert(1);
+}
+
+.mild img {
+  filter: brightness(0);
 }

--- a/Vestib_CI/tilde.svg
+++ b/Vestib_CI/tilde.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="3.5" stroke-linecap="round">
+  <path d="M2 13 C5.5 8, 8.5 8, 12 13 S18.5 18, 22 13"/>
+</svg>

--- a/Vestib_CI/xmark.svg
+++ b/Vestib_CI/xmark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="black" stroke-width="3.5" stroke-linecap="round">
+  <line x1="5" y1="5" x2="19" y2="19"/>
+  <line x1="19" y1="5" x2="5" y2="19"/>
+</svg>


### PR DESCRIPTION
## Summary
This PR modernizes the icon system by replacing raster PNG images with scalable SVG icons and improves the color contrast and accessibility of the state indicator colors.

## Key Changes
- **Icon Format Migration**: Replaced PNG icons (Checked1.png, Tilde1.png, Xmark1.png, Asterisk.png) with SVG equivalents (check.svg, tilde.svg, xmark.svg, asterisk.svg)
- **Color Palette Updates**: Enhanced state indicator colors for better contrast and accessibility:
  - Good state: `green` → `#2a8c2a` (darker green)
  - Mild state: `yellow` → `#d4a800` (darker amber)
  - Severe state: `red` → `#c02020` (darker red)
- **Icon Color Filters**: Added CSS filters to ensure icon visibility across different background colors:
  - Good and severe states: White icons on dark backgrounds using `brightness(0) invert(1)`
  - Mild state: Black icons on amber background using `brightness(0)`

## Implementation Details
- All SVG icons use black strokes with appropriate stroke widths for consistency
- SVG format provides better scalability and smaller file sizes compared to PNG
- CSS filters dynamically adjust icon colors based on the parent state class, eliminating the need for separate icon variants
- The darker color palette improves WCAG contrast ratios for better accessibility

https://claude.ai/code/session_01Engih44478iVf6uDv4GZRG