### PR TITLE
Add warnings popover on hover for Est. SAL BC results

### DIFF
--- a/SAL/SAL2/index.html
+++ b/SAL/SAL2/index.html
@@ -437,6 +437,7 @@
         </div>
       </div>
     </div>
+    <div id="warnings_popover" popover="manual"></div>
     <script src="main.js"></script>
     <script src="norms.js"></script>
   </body>

--- a/SAL/SAL2/main.js
+++ b/SAL/SAL2/main.js
@@ -291,6 +291,7 @@ function updateChart() {
             "⚠️ Initial AC is very high; limits of equipment may not allow enough room to measure.",
           );
         res.innerText = estBC + " dB";
+        res.dataset.warnings = JSON.stringify(warnings);
         if (warnings[0]) {
           res.classList.add("input-error");
         } else {
@@ -343,5 +344,25 @@ const allInputs = document.querySelectorAll('input[type="number"]');
 allInputs.forEach((input) => {
   input.addEventListener("focus", () => {
     input.select();
+  });
+});
+
+// Warnings popover on hover for Est. SAL BC result cells
+const warningsPopover = document.getElementById("warnings_popover");
+document.querySelectorAll('[id^="res"]').forEach((el) => {
+  el.addEventListener("mouseenter", () => {
+    const warnings = JSON.parse(el.dataset.warnings || "[]");
+    if (!warnings.length) return;
+    warningsPopover.innerHTML = warnings
+      .map((w) => `<div>${w}</div>`)
+      .join("");
+    const rect = el.getBoundingClientRect();
+    warningsPopover.style.left = rect.left + window.scrollX + "px";
+    warningsPopover.style.top =
+      rect.bottom + window.scrollY + 8 + "px";
+    warningsPopover.showPopover();
+  });
+  el.addEventListener("mouseleave", () => {
+    warningsPopover.hidePopover();
   });
 });

--- a/SAL/SAL2/styles.css
+++ b/SAL/SAL2/styles.css
@@ -218,6 +218,21 @@ h1 {
 #help_text_modal::backdrop {
   background: rgba(0, 0, 0, 0.5);
 }
+#warnings_popover {
+  position: absolute;
+  margin: 0;
+  padding: 10px 12px;
+  background-color: rgba(255, 243, 224, 1);
+  border: 1px solid var(--error-border);
+  border-radius: 6px;
+  color: #d35400;
+  font-size: 13px;
+  font-weight: bold;
+  line-height: 1.7;
+  max-width: 300px;
+  pointer-events: none;
+}
+
 @media screen and (max-width: 860px) {
   .norm-labels {
     transform: rotate(-45deg);


### PR DESCRIPTION
## Summary
This PR adds an interactive popover that displays warnings when users hover over the Est. SAL BC result cells. Warnings are now stored in the result elements and displayed in a styled popover positioned below the hovered cell.

## Key Changes
- **main.js**: Store warnings data in result elements via `dataset.warnings` attribute and implement popover show/hide logic on mouseenter/mouseleave events
- **styles.css**: Add styling for the warnings popover with custom background color, border, and typography
- **index.html**: Add the warnings popover element with `popover="manual"` attribute

## Implementation Details
- Warnings are serialized to JSON and stored in each result element's `data-warnings` attribute during chart updates
- A single reusable popover element is positioned dynamically based on the hovered result cell's bounding rectangle
- The popover uses the Popover API with manual mode for fine-grained control over show/hide behavior
- Popover styling uses an orange/warning color scheme (`#d35400`) with a light background (`rgba(255, 243, 224, 1)`)
- The popover only displays when warnings are present (non-empty array)

https://claude.ai/code/session_01A2t2ECBMbeMQ9w2UVMEkHM