### PR TITLE
Add SonicLoom: hybrid of FirstFit and Free_Field pages

### DIFF
--- a/SonicLoom/app.js
+++ b/SonicLoom/app.js
@@ -1,0 +1,151 @@
+const audioPlayerA = document.getElementById("audio_player_A");
+const audioPlayerB = document.getElementById("audio_player_B");
+const allPlayers = [audioPlayerA, audioPlayerB];
+
+const loopToggle = document.getElementById("loopToggle");
+const stopAllBtn = document.getElementById("stopAllBtn");
+const audioFileInput = document.getElementById("audioFile");
+const fileNameDisplay = document.getElementById("fileName");
+
+// ── Audio File Selection ───────────────────────────────────────────────────
+let currentObjectURL = null;
+
+audioFileInput.addEventListener("change", () => {
+  const file = audioFileInput.files[0];
+  if (!file) return;
+
+  // Revoke the previous object URL to free memory
+  if (currentObjectURL) {
+    URL.revokeObjectURL(currentObjectURL);
+  }
+
+  currentObjectURL = URL.createObjectURL(file);
+
+  allPlayers.forEach((player) => {
+    player.src = currentObjectURL;
+    player.load();
+  });
+
+  fileNameDisplay.textContent = file.name;
+});
+
+// ── Loop Toggle ────────────────────────────────────────────────────────────
+function applyLoop() {
+  allPlayers.forEach((player) => {
+    player.loop = loopToggle.checked;
+  });
+}
+
+loopToggle.addEventListener("change", applyLoop);
+
+// ── Stop All ───────────────────────────────────────────────────────────────
+function stopAll() {
+  allPlayers.forEach((player) => {
+    player.pause();
+    player.currentTime = 0;
+  });
+  updateStopButtonState();
+}
+
+function updateStopButtonState() {
+  const anyPlaying = allPlayers.some((p) => !p.paused);
+  stopAllBtn.disabled = !anyPlaying;
+}
+
+stopAllBtn.addEventListener("click", stopAll);
+
+allPlayers.forEach((player) => {
+  player.addEventListener("play", updateStopButtonState);
+  player.addEventListener("pause", updateStopButtonState);
+  player.addEventListener("ended", updateStopButtonState);
+});
+
+// Keyboard shortcut: Escape or Enter stops all audio
+document.addEventListener("keyup", (e) => {
+  if (e.key === "Escape" || e.key === "Enter") stopAll();
+});
+
+// ── Volume Buttons & Fill Logic ────────────────────────────────────────────
+function setFill(btn) {
+  const section = btn.parentElement;
+  const buttons = section.querySelectorAll("button[data-volume]");
+
+  // Clear fill/highlight within this section
+  buttons.forEach((b) => b.classList.remove("filled", "highlighted"));
+
+  // Fill clicked button and everything below it (lower volumes)
+  btn.classList.add("filled");
+  let next = btn.nextElementSibling;
+  while (next && next.matches("button[data-volume]")) {
+    next.classList.add("filled");
+    next = next.nextElementSibling;
+  }
+
+  // Cross-section highlighting logic
+  const sectionA = document.getElementById("sectionA");
+  const sectionB = document.getElementById("sectionB");
+  const buttonsA = sectionA.querySelectorAll("button[data-volume]");
+  const buttonsB = sectionB.querySelectorAll("button[data-volume]");
+
+  // Find where section A's fill starts
+  let startIndex = -1;
+  buttonsA.forEach((b, i) => {
+    if (b.classList.contains("filled") && startIndex === -1) startIndex = i;
+  });
+
+  if (section === sectionA) {
+    // Clicking in A clears B's fill and highlights
+    buttonsB.forEach((b) => b.classList.remove("filled", "highlighted"));
+  } else {
+    // Clicking in B: highlight the gap between A's fill start and B's fill start
+    buttonsB.forEach((b) => b.classList.remove("highlighted"));
+
+    const filledCountB = Array.from(buttonsB).filter((b) =>
+      b.classList.contains("filled")
+    ).length;
+
+    if (filledCountB > 0 && startIndex !== -1) {
+      for (let i = startIndex; i < buttonsB.length; i++) {
+        if (buttonsB[i].classList.contains("filled")) break;
+        buttonsB[i].classList.add("highlighted");
+      }
+    }
+  }
+}
+
+function playAudio(event) {
+  if (!currentObjectURL) return;
+
+  // Pause both players before playing the selected one
+  allPlayers.forEach((p) => {
+    p.pause();
+    p.currentTime = 0;
+  });
+
+  const button = event.currentTarget;
+  const volume = parseFloat(button.getAttribute("data-volume"));
+  const sectionId = button.parentElement.id;
+  const player = sectionId === "sectionA" ? audioPlayerA : audioPlayerB;
+
+  player.volume = volume;
+  applyLoop();
+  player.play();
+
+  setFill(button);
+}
+
+document.querySelectorAll("button[data-volume]").forEach((btn) => {
+  btn.addEventListener("click", playAudio);
+});
+
+// ── Heard Indicators ───────────────────────────────────────────────────────
+document.querySelectorAll(".heard-indicator").forEach((indicator) => {
+  indicator.addEventListener("click", (e) => {
+    e.stopPropagation();
+    indicator.classList.toggle("heard");
+  });
+});
+
+// ── Initial State ──────────────────────────────────────────────────────────
+updateStopButtonState();
+applyLoop();

--- a/SonicLoom/index.html
+++ b/SonicLoom/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="style.css" />
+    <title>SonicLoom</title>
+  </head>
+  <body>
+    <nav-bar></nav-bar>
+
+    <div class="layout">
+      <h1>SonicLoom</h1>
+      <p class="subtitle">Weave your audio through the field</p>
+
+      <fieldset class="controls-fieldset">
+        <legend>Controls</legend>
+        <div class="controls-row">
+
+          <div class="control-group">
+            <label for="audioFile">Audio File</label>
+            <label class="file-btn" for="audioFile">
+              Choose File
+              <input type="file" id="audioFile" accept="audio/*" />
+            </label>
+            <span id="fileName" class="file-name">No file selected</span>
+          </div>
+
+          <button id="stopAllBtn" class="stop-btn">&#9646; Stop All</button>
+
+          <div class="control-group loop-group">
+            <label for="loopToggle">Loop</label>
+            <input type="checkbox" id="loopToggle" />
+          </div>
+
+        </div>
+      </fieldset>
+
+      <div class="btn-column-wrapper">
+
+        <div class="btn-column" id="sectionA">
+          <h2 class="column-header">Test One</h2>
+          <audio id="audio_player_A" preload="auto" class="audio-player"></audio>
+          <button data-volume="1.0">10 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.9">9 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.8">8 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.7">7 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.6">6 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.5">5 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.4">4 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.3">3 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.2">2 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.1">1 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0">0 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+        </div>
+
+        <div class="btn-column" id="sectionB">
+          <h2 class="column-header">Test Two</h2>
+          <audio id="audio_player_B" preload="auto" class="audio-player"></audio>
+          <button data-volume="1.0">10 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.9">9 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.8">8 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.7">7 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.6">6 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.5">5 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.4">4 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.3">3 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.2">2 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0.1">1 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+          <button data-volume="0">0 <span class="heard-indicator" title="I heard this">&#10003;</span></button>
+        </div>
+
+      </div>
+    </div>
+
+    <script src="../Components/NavBar.js"></script>
+    <script src="app.js"></script>
+  </body>
+</html>

--- a/SonicLoom/style.css
+++ b/SonicLoom/style.css
@@ -1,0 +1,257 @@
+:root {
+  --primary: #6707ed;
+  --bg: #1e2530;
+  --container-bg: #2b3240;
+  --surface: #343d4e;
+  --border: #4a5568;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --accent: #74c0fc;
+  --accent-hover: #a5d8ff;
+  --filled: #4a6fa5;
+  --filled-text: #e2e8f0;
+  --highlighted: #7bb661;
+  --heard-green: #2ecc71;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  background-color: var(--bg);
+  color: var(--text);
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+}
+
+nav-bar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.layout {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.5rem;
+  max-width: 700px;
+  margin: auto;
+  padding: 2rem 1rem 3rem;
+}
+
+h1 {
+  font-size: 2.2rem;
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  margin: 0;
+  background: linear-gradient(135deg, var(--accent) 0%, var(--primary) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  letter-spacing: 0.04em;
+}
+
+/* ── Controls Fieldset ── */
+.controls-fieldset {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: var(--container-bg);
+  padding: 1.25rem 1.5rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+}
+
+.controls-fieldset legend {
+  font-size: 0.78rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--text-muted);
+  padding: 0 0.5rem;
+}
+
+.controls-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.control-group {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.control-group label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+/* File input — hidden, triggered by styled label */
+input[type="file"] {
+  display: none;
+}
+
+.file-btn {
+  display: inline-block;
+  padding: 0.4rem 0.9rem;
+  background: var(--surface);
+  border: 1px solid var(--accent);
+  border-radius: 7px;
+  color: var(--accent);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.18s, color 0.18s;
+}
+
+.file-btn:hover {
+  background: var(--accent);
+  color: #111;
+}
+
+.file-name {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Stop button */
+.stop-btn {
+  padding: 0.45rem 1.1rem;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: var(--text);
+  font-size: 0.9rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.18s, border-color 0.18s, color 0.18s;
+}
+
+.stop-btn:hover:not(:disabled) {
+  background: #4a1515;
+  border-color: #e05555;
+  color: #f99;
+}
+
+.stop-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Loop checkbox */
+.loop-group label {
+  cursor: pointer;
+}
+
+input[type="checkbox"] {
+  width: 1.15rem;
+  height: 1.15rem;
+  cursor: pointer;
+  accent-color: var(--primary);
+}
+
+/* ── Two-column button grid ── */
+.btn-column-wrapper {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2.5rem;
+  width: 100%;
+}
+
+.btn-column {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.65rem;
+}
+
+.column-header {
+  margin: 0 0 0.25rem;
+  text-align: center;
+  font-size: 1rem;
+  font-weight: 700;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  border-radius: 30px;
+  padding: 0.35rem 0;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  letter-spacing: 0.04em;
+}
+
+/* Volume buttons */
+button[data-volume] {
+  border: 1px solid var(--accent);
+  border-radius: 6px;
+  background-color: transparent;
+  color: var(--accent-hover);
+  cursor: pointer;
+  font-weight: 700;
+  font-size: max(0.9rem, min(3vw, 1.1rem));
+  padding: 0.45rem 0;
+  width: 100%;
+  transition: background 0.15s, color 0.15s, border-color 0.15s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+}
+
+button[data-volume]:hover {
+  background-color: var(--accent);
+  color: #111;
+}
+
+button[data-volume].filled {
+  background-color: var(--filled);
+  border-color: var(--filled);
+  color: var(--filled-text);
+}
+
+button[data-volume].highlighted {
+  background-color: var(--highlighted);
+  border-color: var(--highlighted);
+  color: #111;
+}
+
+/* Audio players — hidden but functional */
+.audio-player {
+  display: none;
+}
+
+/* Heard indicator */
+.heard-indicator {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.1rem;
+  height: 1.1rem;
+  border: 2px solid currentColor;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  opacity: 0.2;
+  transition: opacity 0.15s, background-color 0.15s;
+  flex-shrink: 0;
+}
+
+.heard-indicator.heard {
+  opacity: 1;
+  background-color: var(--heard-green);
+  border-color: #27ae60;
+  color: #111;
+}


### PR DESCRIPTION
Combines Free_Field's two-column volume button layout (with heard indicators
and fill/highlight logic) with FirstFit's loop toggle. Adds a user-facing
audio file picker that loads a local file into both test players via
URL.createObjectURL, replacing the hardcoded m4a source.

https://claude.ai/code/session_01QF9RGWu44Gq9EccRXqT6p8