### PR TITLE
Add page title support to NavBar component

### DIFF
--- a/Components/NavBar.js
+++ b/Components/NavBar.js
@@ -55,6 +55,20 @@ class NavBar extends HTMLElement {
           width: 16px;
           height: 16px;
         }
+
+        .page-title {
+          font-size: 0.8rem;
+          font-weight: 400;
+          color: #6b7280;
+          letter-spacing: 0.01em;
+        }
+
+        ::slotted([slot="page-title"]) {
+          font-size: 0.8rem;
+          font-weight: 400;
+          color: #6b7280;
+          letter-spacing: 0.01em;
+        }
       </style>
 
       <nav>
@@ -64,6 +78,7 @@ class NavBar extends HTMLElement {
           </svg>
           Back
         </button>
+        <span class="page-title"><slot name="page-title"></slot></span>
       </nav>
     `;
 

--- a/SAL/SAL2/index.html
+++ b/SAL/SAL2/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="styles.css" />
   </head>
   <body>
-    <nav-bar></nav-bar>
+    <nav-bar><span slot="page-title">Sensorineural Acuity Level (masking dilemma)</span></nav-bar>
     <div class="container">
       <header>
         <div>


### PR DESCRIPTION
## Summary
Added support for displaying a customizable page title in the NavBar component using the slot mechanism, allowing parent components to pass in their own page title content.

## Key Changes
- Added `.page-title` and `::slotted([slot="page-title"])` CSS styles to NavBar component with consistent typography (0.8rem font size, 400 weight, gray color #6b7280)
- Added a `<span class="page-title">` element with a named slot (`page-title`) to the NavBar template
- Updated SAL2 index.html to pass "Sensorineural Acuity Level (masking dilemma)" as the page title through the slot

## Implementation Details
The page title is implemented as a named slot, enabling flexible content projection while maintaining consistent styling. The dual CSS rules (class selector and `::slotted()` pseudo-element) ensure proper styling of both the container and slotted content.

https://claude.ai/code/session_01UoHdWcpM6r6cnxqe1UpD1J