### PR TITLE
Add timed loop duration options to audio player

### DIFF
--- a/SonicLoom/app.js
+++ b/SonicLoom/app.js
@@ -3,6 +3,7 @@ const audioPlayerB = document.getElementById("audio_player_B");
 const allPlayers = [audioPlayerA, audioPlayerB];
 
 const loopToggle = document.getElementById("loopToggle");
+const loopLengthGroup = document.getElementById("loopLengthGroup");
 const stopAllBtn = document.getElementById("stopAllBtn");
 const audioFileInput = document.getElementById("audioFile");
 
@@ -17,17 +18,56 @@ audioFileInput.addEventListener("change", () => {
   });
 });
 
-// ── Loop Toggle ────────────────────────────────────────────────────────────
+// ── Loop Toggle & Length ────────────────────────────────────────────────────
+let loopLengthTimeout = null;
+
+function getLoopDuration() {
+  const selected = document.querySelector('input[name="loopLength"]:checked');
+  return selected ? selected.value : "forever";
+}
+
+function clearLoopTimer() {
+  if (loopLengthTimeout !== null) {
+    clearTimeout(loopLengthTimeout);
+    loopLengthTimeout = null;
+  }
+}
+
 function applyLoop() {
+  const looping = loopToggle.checked;
+  const duration = getLoopDuration();
   allPlayers.forEach((player) => {
-    player.loop = loopToggle.checked;
+    player.loop = looping && duration === "forever";
   });
+  loopLengthGroup.style.visibility = looping ? "visible" : "hidden";
+}
+
+function startLoopTimer() {
+  clearLoopTimer();
+  if (!loopToggle.checked) return;
+  const duration = getLoopDuration();
+  if (duration === "forever") return;
+
+  loopLengthTimeout = setTimeout(() => {
+    stopAll();
+  }, parseInt(duration) * 1000);
 }
 
 loopToggle.addEventListener("change", applyLoop);
 
+document.querySelectorAll('input[name="loopLength"]').forEach((radio) => {
+  radio.addEventListener("change", () => {
+    applyLoop();
+    // If audio is currently playing with a timed loop, restart the timer
+    if (loopToggle.checked && allPlayers.some((p) => !p.paused)) {
+      startLoopTimer();
+    }
+  });
+});
+
 // ── Stop All ───────────────────────────────────────────────────────────────
 function stopAll() {
+  clearLoopTimer();
   allPlayers.forEach((player) => {
     player.pause();
     player.currentTime = 0;
@@ -130,6 +170,7 @@ function playAudio(event) {
   player.volume = volume;
   applyLoop();
   player.play();
+  startLoopTimer();
   activeButton = button;
 
   setFill(button);

--- a/SonicLoom/index.html
+++ b/SonicLoom/index.html
@@ -29,6 +29,11 @@
           <div class="control-group loop-group">
             <label for="loopToggle">Loop</label>
             <input type="checkbox" id="loopToggle" />
+            <div class="loop-length-group" id="loopLengthGroup">
+              <label><input type="radio" name="loopLength" value="forever" checked /> Forever</label>
+              <label><input type="radio" name="loopLength" value="5" /> 5 seconds</label>
+              <label><input type="radio" name="loopLength" value="10" /> 10 seconds</label>
+            </div>
           </div>
         </div>
       </fieldset>

--- a/SonicLoom/style.css
+++ b/SonicLoom/style.css
@@ -171,6 +171,31 @@ input[type="checkbox"] {
   accent-color: var(--primary);
 }
 
+/* Loop length radio group */
+.loop-length-group {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-left: 0.5rem;
+  visibility: hidden;
+}
+
+.loop-length-group label {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-muted);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.loop-length-group input[type="radio"] {
+  accent-color: var(--primary);
+  cursor: pointer;
+}
+
 /* ── Two-column button grid ── */
 .btn-column-wrapper {
   display: grid;


### PR DESCRIPTION
## Summary
This PR adds the ability to set a maximum duration for audio loops, allowing users to loop audio for a fixed time period (5 or 10 seconds) or indefinitely. When a timed loop expires, playback automatically stops.

## Key Changes
- **Loop duration selection**: Added radio button group with three options (Forever, 5 seconds, 10 seconds) that appears when loop is enabled
- **Timer management**: Implemented `startLoopTimer()` and `clearLoopTimer()` functions to handle automatic playback stop when timed loops expire
- **Loop behavior update**: Modified `applyLoop()` to only enable native HTML5 looping for "forever" mode; timed loops are managed via JavaScript timers
- **UI visibility**: Loop length options are hidden by default and shown only when loop toggle is active
- **Styling**: Added CSS for the loop length radio group with proper alignment and spacing

## Implementation Details
- Loop timer is cleared when stopping audio or changing loop settings
- Timer is restarted when loop duration is changed during playback
- Timer is initialized when audio playback starts with loop enabled
- Uses `setTimeout()` to trigger `stopAll()` after the selected duration expires
- Radio button change events trigger both UI updates and timer restart if audio is currently playing

https://claude.ai/code/session_01Mx2bSW6EdnUaZYPhbQWKKk