### PR TITLE
Restore focus to text area after clearing display

### DIFF
--- a/Loud_Text/index.js
+++ b/Loud_Text/index.js
@@ -94,6 +94,7 @@ clearBtn.addEventListener("click", clearDisplayText);
 function clearDisplayText() {
   displayArea.innerHTML = "";
   inputText.value = "";
+  inputText.focus();
 }
 
 window.addEventListener("keydown", function (e) {


### PR DESCRIPTION
After Ctrl+Enter clears the display, focus returns to the input
text area so the user can immediately start typing again.

https://claude.ai/code/session_01JYXSXGP85N4xBRzbym3jAa