### PR TITLE
Add frequency viz strip above frequency stepper

### DIFF
--- a/Spot_Check/index.html
+++ b/Spot_Check/index.html
@@ -68,23 +68,26 @@
           <h2 class="section-title">Audiometer Signal</h2>
           <div class="control-row">
             <label class="control-label">Frequency</label>
-            <div class="stepper">
-              <button class="stepper-btn" onclick="changeFreq('up')">
-                &#8249;
-              </button>
-              <select id="stim_freq" class="stepper-select">
-                <option>250 Hz</option>
-                <option>500 Hz</option>
-                <option selected>1000 Hz</option>
-                <option>2000 Hz</option>
-                <option>3000 Hz</option>
-                <option>4000 Hz</option>
-                <option>6000 Hz</option>
-                <option>8000 Hz</option>
-              </select>
-              <button class="stepper-btn" onclick="changeFreq('down')">
-                &#8250;
-              </button>
+            <div class="freq-stepper-wrap">
+              <div class="freq-viz" id="freqViz"></div>
+              <div class="stepper">
+                <button class="stepper-btn" onclick="changeFreq('up')">
+                  &#8249;
+                </button>
+                <select id="stim_freq" class="stepper-select">
+                  <option>250 Hz</option>
+                  <option>500 Hz</option>
+                  <option selected>1000 Hz</option>
+                  <option>2000 Hz</option>
+                  <option>3000 Hz</option>
+                  <option>4000 Hz</option>
+                  <option>6000 Hz</option>
+                  <option>8000 Hz</option>
+                </select>
+                <button class="stepper-btn" onclick="changeFreq('down')">
+                  &#8250;
+                </button>
+              </div>
             </div>
           </div>
           <div class="control-row">

--- a/Spot_Check/script.js
+++ b/Spot_Check/script.js
@@ -286,8 +286,29 @@ function updateSaveButtonText() {
   document.getElementById("save").textContent = "Save Now (" + formatFreqLabel(freqString) + ")";
 }
 
+function buildFreqViz() {
+  const viz = document.getElementById("freqViz");
+  const select = document.getElementById("stim_freq");
+  for (const option of select.options) {
+    const span = document.createElement("span");
+    span.className = "freq-viz-label";
+    span.textContent = formatFreqLabel(option.value);
+    viz.appendChild(span);
+  }
+}
+
+function updateFreqViz() {
+  const select = document.getElementById("stim_freq");
+  document.querySelectorAll(".freq-viz-label").forEach((label, i) => {
+    label.classList.toggle("active", i === select.selectedIndex);
+  });
+}
+
 document.getElementById("stim_freq").addEventListener("change", updateSaveButtonText);
+document.getElementById("stim_freq").addEventListener("change", updateFreqViz);
+buildFreqViz();
 updateSaveButtonText();
+updateFreqViz();
 
 function changeFreq(direction) {
   const select = document.getElementById("stim_freq");

--- a/Spot_Check/style.css
+++ b/Spot_Check/style.css
@@ -301,6 +301,32 @@ a.icon-btn {
   flex-shrink: 0;
 }
 
+/* ── Freq viz strip ── */
+.freq-stepper-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.freq-viz {
+  display: flex;
+  justify-content: space-between;
+}
+
+.freq-viz-label {
+  font-size: 9px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  line-height: 1;
+  transition: color 0.15s, font-weight 0.15s;
+  user-select: none;
+}
+
+.freq-viz-label.active {
+  color: var(--accent);
+  font-weight: 700;
+}
+
 /* ── Stepper ── */
 .stepper {
   display: flex;


### PR DESCRIPTION
Renders a row of all freq options (250Hz–8kHz) in shortened form above the stepper, with the selected frequency highlighted in accent colour and bolded. Updates on every frequency change.

https://claude.ai/code/session_01Ge16J8GveofLHdfpgVehzv