### PR TITLE
Disable double-tap zoom on stepper buttons

### DIFF
--- a/Spot_Check/style.css
+++ b/Spot_Check/style.css
@@ -353,6 +353,7 @@ a.icon-btn {
   justify-content: center;
   flex-shrink: 0;
   transition: background 0.12s;
+  touch-action: manipulation;
 }
 
 .stepper-btn:hover {


### PR DESCRIPTION
touch-action: manipulation suppresses the 300ms double-tap-to-zoom gesture on the stepper buttons without disabling other touch behaviour.

https://claude.ai/code/session_01Ge16J8GveofLHdfpgVehzv