### PR TITLE
Reorganize monitor controls: hide save buttons until monitoring starts

### DIFF
--- a/Spot_Check/index.html
+++ b/Spot_Check/index.html
@@ -52,10 +52,10 @@
           <button id="startBtn" class="btn btn-start">
             &#9679; Start Monitoring
           </button>
-          <button id="stopBtn" class="btn btn-stop" style="display: none">
-            &#9632; Stop Monitoring
-          </button>
-          <div class="save-section">
+          <div class="monitor-active-row" id="monitorActiveRow" style="display: none;">
+            <button id="stopBtn" class="btn btn-stop">
+              &#9632; Stop
+            </button>
             <button id="saveDelay" class="btn btn-save-delay" disabled>
               Save in 3 s
             </button>

--- a/Spot_Check/script.js
+++ b/Spot_Check/script.js
@@ -143,7 +143,7 @@ async function startMonitoring() {
     levelText.classList.add("level-value--active");
     levelUnit.style.display = "";
     startBtn.style.display = "none";
-    stopBtn.style.display = "block";
+    document.getElementById("monitorActiveRow").style.display = "flex";
     document.getElementById("save").disabled = false;
     document.getElementById("saveDelay").disabled = false;
   } catch (err) {
@@ -162,8 +162,8 @@ function stopMonitoring() {
   ctx.clearRect(0, 0, canvas.width, canvas.height);
   peakText.textContent = "—";
 
-  startBtn.style.display = "block";
-  stopBtn.style.display = "none";
+  startBtn.style.display = "";
+  document.getElementById("monitorActiveRow").style.display = "none";
   document.getElementById("save").disabled = true;
   document.getElementById("saveDelay").disabled = true;
   meterFill.style.width = "0%";

--- a/Spot_Check/style.css
+++ b/Spot_Check/style.css
@@ -189,6 +189,16 @@ a.icon-btn {
   gap: 10px;
 }
 
+.monitor-active-row {
+  display: flex;
+  gap: 8px;
+}
+
+.monitor-active-row .btn {
+  width: auto;
+  flex: 1;
+}
+
 
 /* ── Buttons ── */
 .btn {
@@ -263,11 +273,6 @@ a.icon-btn {
   transform: scale(0.98);
 }
 
-/* ── Save section ── */
-.save-section {
-  display: flex;
-  gap: 10px;
-}
 
 /* ── Controls sections ── */
 .controls-section {


### PR DESCRIPTION
- Start button is full width when not monitoring; save buttons hidden
- When monitoring, Stop + Save in 3s + Save Now appear inline in one row
- Shortened stop button label to "Stop" to fit the inline layout

https://claude.ai/code/session_01QcMaQPKXrfZ5HbkWevBRtE