### PR TITLE
Add close button to help modal for mobile usability

### DIFF
--- a/Spot_Check/index.html
+++ b/Spot_Check/index.html
@@ -169,7 +169,15 @@
 
     <div id="instructions" popover>
       <div id="instructions_content">
-        <h2>How to use</h2>
+        <div class="instructions-header">
+          <h2>How to use</h2>
+          <button
+            popovertarget="instructions"
+            popovertargetaction="hide"
+            class="icon-btn"
+            aria-label="Close"
+          >&#10005;</button>
+        </div>
         <p>
           Place your phone at ear level in the sound field, with the mic
           facing the speaker.

--- a/Spot_Check/style.css
+++ b/Spot_Check/style.css
@@ -501,6 +501,12 @@ input[type="date"].text-input {
   gap: 12px;
 }
 
+.instructions-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 #instructions_content h2 {
   font-size: 17px;
   font-weight: 700;


### PR DESCRIPTION
Light-dismiss can be hard to trigger on small screens, so a close button is added to the modal header using the popover hide action.

https://claude.ai/code/session_012aNkEzR1mt7VciMuQqUjBT